### PR TITLE
Use proper enums for spacecraft

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,7 @@
 name: Linux
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,7 +1,6 @@
 name: Linux
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - master
@@ -44,38 +43,47 @@ jobs:
         with:
           submodules: recursive
           fetch-tags: true
+          fetch-depth: 0
 
       # Temporary solution
       - name: Remove unused dependencies
         run: |
           rm -rf libs/Frameworks
-          rm -rf libs/sdl2
+          rm -rf libs/libevents
+          rm -rf libs/mavlink
           rm -rf libs/OpenSSL
+          rm -rf libs/sdl2
 
       - name: Install Dependencies
         run: |
           chmod a+x ./tools/setup/install-dependencies-debian.sh
           sudo ./tools/setup/install-dependencies-debian.sh
-          sudo apt clean
+          python3 -m pip install --user ninja cmake
 
-      - name: Install Build Tools
+      - name: Install Vulkan
+        run: |
+          wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.283-focal.list https://packages.lunarg.com/vulkan/1.3.283/lunarg-vulkan-1.3.283-focal.list
+          sudo apt update
+          sudo apt install vulkan-sdk
+
+      - name: Install Compiler
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt install gcc-13 g++-13
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 --slave /usr/bin/g++ g++ /usr/bin/g++-13 --slave /usr/bin/gcov gcov /usr/bin/gcov-13
+          sudo update-alternatives --set gcc /usr/bin/gcc-13
+
+      - name: Install CCache
         run: |
           wget --quiet https://github.com/ccache/ccache/releases/download/v4.9.1/ccache-4.9.1-linux-x86_64.tar.xz
           tar -xvf ccache-*-linux-x86_64.tar.xz
           cd ccache-*-linux-x86_64
           sudo make install
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          sudo apt install gcc-13 g++-13
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 --slave /usr/bin/g++ g++ /usr/bin/g++-13 --slave /usr/bin/gcov gcov /usr/bin/gcov-13
-          sudo update-alternatives --set gcc /usr/bin/gcc-13
-          python3 -m pip install --user ninja meson
 
-      - name: Install Vulkan
-        run: |
-          wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-focal.list http://packages.lunarg.com/vulkan/lunarg-vulkan-focal.list
-          sudo apt update
-          sudo apt install vulkan-sdk
+      - name: Install Unit-Test Dependencies
+        if: matrix.BuildType == 'Debug'
+        run: sudo apt install xvfb x11-xserver-utils
 
       - name: Set Up Cache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -88,23 +96,22 @@ jobs:
           save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: ${{ env.QT_VERSION }}
           aqtversion: ==3.1.*
           host: linux
           target: desktop
           dir: ${{ runner.temp }}
-          modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
+          modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
           setup-python: true
           cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
-          tools: 'tools_cmake'
+
+      - name: Installation Cleanup
+        run: sudo apt clean
 
     # - name: Build GStreamer
     #   uses: ./.github/actions/gstreamer
-
-      - name: Cleanup
-        run: sudo apt clean
 
       - name: Create build directory
         run:  mkdir ${{ runner.temp }}/shadow_build_dir

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/PX4/GpsDrivers.git
 [submodule "libs/mavlink/include/mavlink/v2.0"]
 	path = libs/mavlink/include/mavlink/v2.0
-	url = https://github.com/DISCOWER/mavlink.git
+	url = https://github.com/DISCOWER/c_library_v2.git
 [submodule "libs/OpenSSL/android_openssl"]
 	path = libs/OpenSSL/android_openssl
 	url = https://github.com/KDAB/android_openssl

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/PX4/GpsDrivers.git
 [submodule "libs/mavlink/include/mavlink/v2.0"]
 	path = libs/mavlink/include/mavlink/v2.0
-	url = https://github.com/mavlink/c_library_v2.git
+	url = https://github.com/DISCOWER/mavlink.git
 [submodule "libs/OpenSSL/android_openssl"]
 	path = libs/OpenSSL/android_openssl
 	url = https://github.com/KDAB/android_openssl

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponent.cc
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponent.cc
@@ -75,7 +75,7 @@ QUrl PX4TuningComponent::setupSource(void) const
         case MAV_TYPE_VTOL_RESERVED5:
             qmlFile = "qrc:/qml/PX4TuningComponentVTOL.qml";
             break;
-        case 99:
+        case MAV_TYPE_SPACECRAFT:
             // Spacecraft Type
             qmlFile = "qrc:/qml/PX4TuningComponentSpacecraft.qml";
         default:


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
This PR adds a custom mavlink library from DISCOWER/mavlink, such that proper enums can be used for the spacecraft pid UI.

The code with not compile with me when trying to compile on Ubuntu 22.04, Qt 6.6.3

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [ ] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ ] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.